### PR TITLE
Add  LibreSelery

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ I found no way to buy bitcoin anonymously, by adequate rate, outside of US and E
 - [Melon](https://melonport.com/) - Blockchain Software for Asset Management
 - [BlockVotes](https://github.com/yfgeek/BlockVotes) - E-voting system based on ring signatures
 - [RIF OS](https://www.rifos.org/) - Decentralized infrastructure services such as Directory, Payments, Storage, Communications, and Data Gateways.
+- [LibreSelery](https://github.com/protontypes/libreselery) - Continuous funding distribution to your project contributors and dependencies. Integrated into Github Actions and Coinbase
 
 ### Games
 


### PR DESCRIPTION
Added [LibreSelery](https://github.com/protontypes/libreselery). It is a new DeFi concept for software funding.
More information on our first organization blog post:
https://protontypes.eu/blog/2020/09/02/launch-of-protontypes/ 

The concept was already tested for developing LibreSelery itself. I invested around 2000€ in the development and distributed the donation among the contributors to the main project and some contributors to our dependencies. 

![](https://raw.githubusercontent.com/wiki/protontypes/libreselery/libreselery/transactions_per_user.png)

It would also be nice to get some feedback on this new concept. 