### PR TITLE
Add Haveno DEX to Decentralized Exchanges section

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ I found no way to buy bitcoin anonymously, by adequate rate, outside of US and E
 
 #### DEX (Decentralized Exchanges)
 
+- [Haveno DEX](https://haveno.exchange) - Fully decentralized P2P exchange for Monero (XMR). Non-custodial, 2-of-3 multisig escrow, NO KYC. Uses Tor. Active networks: [RetosSwap](https://retoswap.com) ($2M+/month volume), [DawnSwap](https://dawnswap.com) (5% deposits, 24/7 arbitration). Supports Cash by Mail, Face-to-Face, bank transfer.
+
 - [ForkDelta](https://forkdelta.github.io)
 - [IDEX](https://idex.market/)
 - [Ordermatch](https://ordermatch.io/) - 0x relayer


### PR DESCRIPTION
Adds [Haveno DEX](https://haveno.exchange) to the Decentralized Exchanges section.

Haveno is a fully decentralized, non-custodial P2P exchange built on Monero. It uses 2-of-3 multisig escrow and Tor for privacy. Two major networks are currently operational:

- **RetosSwap** — $2M+/month volume, the largest Haveno network
- **DawnSwap** — Lower deposits (5%), 24/7 arbitration

Both support a wide range of payment methods including Cash by Mail, Face-to-Face, and bank transfers. No KYC required.

This fills a gap in the DEX section which currently has no Monero-native decentralized exchange listed.